### PR TITLE
add the missing LUALIB var in posix make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ posix : hive.so
 macosx: hive.dylib
 
 hive.so : $(SRC)
-	gcc -g -Wall --shared -fPIC -o $@ $^ -lpthread
+	gcc -g -Wall --shared -fPIC -o $@ $^ $(LUALIB) -lpthread
 
 hive.dll : $(SRC)
 	gcc -g -Wall --shared -o $@ $^ $(LUALIB) -lpthread -march=i686


### PR DESCRIPTION
And -L shouldn't follow by /usr/local/bin, in FreeBSD, it should be /usr/local/lib/lua52, but this is related to installer's OS.
